### PR TITLE
update to separate tokens for download and upload

### DIFF
--- a/modules/icgc-argo-workflows/score/download/main.nf
+++ b/modules/icgc-argo-workflows/score/download/main.nf
@@ -1,5 +1,3 @@
-
-
 process SCORE_DOWNLOAD {
     tag "${analysis_id}"
     label 'process_medium'
@@ -32,7 +30,7 @@ process SCORE_DOWNLOAD {
     def score_url = params.score_url_download ?: params.score_url
     def transport_parallel = params.transport_parallel ?: task.cpus
     def transport_mem = params.transport_mem ?: "2"
-    def accessToken = params.api_token ?: "`cat /tmp/rdpc_secret/secret`"
+    def accessToken = task.ext.api_download_token ?: "`cat /tmp/rdpc_secret/secret`"
     def VERSION = params.score_container_version ?: '5.8.1'
     """
     export METADATA_URL=${song_url}

--- a/modules/icgc-argo-workflows/score/upload/main.nf
+++ b/modules/icgc-argo-workflows/score/upload/main.nf
@@ -1,5 +1,4 @@
 
-
 process SCORE_UPLOAD {
     tag "${analysis_id}"
     label 'process_medium'
@@ -29,7 +28,7 @@ process SCORE_UPLOAD {
     def score_url = params.score_url_upload ?: params.score_url
     def transport_parallel = params.transport_parallel ?: task.cpus
     def transport_mem = params.transport_mem ?: "2"
-    def accessToken = params.api_token ?: "`cat /tmp/rdpc_secret/secret`"
+    def accessToken = task.ext.api_upload_token ?: "`cat /tmp/rdpc_secret/secret`"
     def VERSION = params.score_container_version ?: '5.8.1'
     """
     export METADATA_URL=${song_url}

--- a/modules/icgc-argo-workflows/song/get/main.nf
+++ b/modules/icgc-argo-workflows/song/get/main.nf
@@ -26,7 +26,7 @@ process SONG_GET {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${analysis_id}"
     def song_url = params.song_url_download ?: params.song_url
-    def accessToken = params.api_token ?: "`cat /tmp/rdpc_secret/secret`"
+    def accessToken = task.ext.api_download_token ?: "`cat /tmp/rdpc_secret/secret`"
     def VERSION = params.song_container_version ?: '5.0.2'
     """
     export CLIENT_SERVER_URL=${song_url}

--- a/modules/icgc-argo-workflows/song/manifest/main.nf
+++ b/modules/icgc-argo-workflows/song/manifest/main.nf
@@ -1,4 +1,3 @@
-
 process SONG_MANIFEST {
     tag "${analysis_id}"
     label 'process_single'
@@ -26,7 +25,7 @@ process SONG_MANIFEST {
     script:
     def args = task.ext.args ?: ''
     def song_url = params.song_url_upload ?: params.song_url
-    def accessToken = params.api_token ?: "`cat /tmp/rdpc_secret/secret`"
+    def accessToken = task.ext.api_upload_token ?: "`cat /tmp/rdpc_secret/secret`"
     def VERSION = params.song_container_version ?: '5.0.2'
     def study_id = "${meta.study_id}"
     """

--- a/modules/icgc-argo-workflows/song/publish/main.nf
+++ b/modules/icgc-argo-workflows/song/publish/main.nf
@@ -1,4 +1,3 @@
-
 process SONG_PUBLISH {
     tag "${analysis_id}"
     label 'process_single'
@@ -25,7 +24,7 @@ process SONG_PUBLISH {
     script:
     def args = task.ext.args ?: ''
     def song_url = params.song_url_upload ?: params.song_url
-    def accessToken = params.api_token ?: "`cat /tmp/rdpc_secret/secret`"
+    def accessToken = task.ext.api_upload_token ?: "`cat /tmp/rdpc_secret/secret`"
     def study_id = "${meta.study_id}"
     def VERSION = params.song_container_version ?: '5.0.2'
     """

--- a/modules/icgc-argo-workflows/song/submit/main.nf
+++ b/modules/icgc-argo-workflows/song/submit/main.nf
@@ -27,7 +27,7 @@ process SONG_SUBMIT {
     script:
     def args = task.ext.args ?: ''
     def song_url = params.song_url_upload ?: params.song_url
-    def accessToken = params.api_token ?: "`cat /tmp/rdpc_secret/secret`"
+    def accessToken = task.ext.api_upload_token ?: "`cat /tmp/rdpc_secret/secret`"
     def VERSION = params.song_container_version ?: '5.0.2'
     def study_id = "${meta.study_id}"
     """

--- a/tests/config/modules.config
+++ b/tests/config/modules.config
@@ -18,5 +18,27 @@ process {
         enabled: params.outdir ? true : false,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
-         
+    
+    withName: 'SONG.*|SCORE.*' {
+      ext.prefix = ""
+      ext.transport_parallel = params.transport_parallel 
+      ext.transport_mem = params.transport_mem
+      ext.api_download_token = params.api_token ?: params.api_download_token
+      ext.api_upload_token = params.api_token ?: params.api_upload_token
+      ext.song_container_version = params.song_container_version
+      ext.song_container = params.song_container
+      ext.score_container_version = params.score_container_version
+      ext.score_container = params.score_container
+    }
+
+    withName: 'SONG_GET|SCORE_DOWNLOAD' {
+      ext.song_url = params.song_url_download ?: params.song_url
+      ext.score_url = params.score_url_download ?: params.score_url
+    }
+
+
+    withName: 'SONG_SUBMIT|SONG_MANIFEST|SONG_PUBLISH|SCORE_UPLOAD' {
+      ext.song_url = params.song_url_upload ?: params.song_url 
+      ext.score_url = params.score_url_upload ?: params.score_url
+    }        
 }

--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -13,6 +13,8 @@ params {
 
     // song/score setting 
     api_token                  = null
+    api_download_token         = null
+    api_upload_token           = null
     song_url                   = null
     score_url                  = null
     song_url_download          = null


### PR DESCRIPTION
Update `api_token` to be the default supplied, otherwise `api_download_token` and `api_upload_token` can be used:

The following is equivalent:
```
nextflow run ./tests/subworkflows/icgc-argo-workflows/song_score_upload -entry test_song_score_upload_rdpcqa -c ./tests/config/nextflow.config -profile docker,debug_qa --api_token ${token}
nextflow run ./tests/subworkflows/icgc-argo-workflows/song_score_download -entry test_song_score_download_rdpcqa -c ./tests/config/nextflow.config -profile docker,debug_qa --api_token ${token}
```
to
```
nextflow run ./tests/subworkflows/icgc-argo-workflows/song_score_upload -entry test_song_score_upload_rdpcqa -c ./tests/config/nextflow.config -profile docker,debug_qa --api_upload_token ${token}
nextflow run ./tests/subworkflows/icgc-argo-workflows/song_score_download -entry test_song_score_download_rdpcqa -c ./tests/config/nextflow.config -profile docker,debug_qa --api_download_token ${token}
```